### PR TITLE
Build in docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+Dockerfile
+.travis.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,20 @@
 FROM alpine:latest
 LABEL maintainer="support@messagebird.com"
 
-# Copy over the binary in the container.
-ADD bin/pushprom /usr/bin/
+ENV GOPATH=/usr/local
+
+RUN apk add --no-cache musl-dev go git && \
+    go get -u github.com/golang/dep/cmd/dep
+
+ADD . /usr/local/src/pushprom
+WORKDIR /usr/local/src/pushprom
+
+RUN dep ensure -v && \
+    go test && \
+    GOOS=linux GOARCH=amd64 CGO_ENABLED=1 go build -ldflags "-s -w" -o "/usr/local/bin/pushprom"
 
 EXPOSE 9090 9091
 
 # Run
-CMD ["/usr/bin/pushprom"]
-
+CMD ["/usr/local/bin/pushprom"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:latest
-MAINTAINER MessageBird <support@messagebird.com>
+LABEL maintainer="support@messagebird.com"
 
 # Copy over the binary in the container.
 ADD bin/pushprom /usr/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM alpine:latest
+# ##### builder stage #####
+FROM alpine:latest AS builder
 LABEL maintainer="support@messagebird.com"
 
 ENV GOPATH=/usr/local
@@ -12,6 +13,10 @@ WORKDIR /usr/local/src/pushprom
 RUN dep ensure -v && \
     go test && \
     GOOS=linux GOARCH=amd64 CGO_ENABLED=1 go build -ldflags "-s -w" -o "/usr/local/bin/pushprom"
+
+# ##### image stage #####
+FROM alpine:latest
+COPY --from=builder /usr/local/bin/pushprom /usr/local/bin/pushprom
 
 EXPOSE 9090 9091
 


### PR DESCRIPTION
This PR is related to the goals outlined in #17 - to get the image at https://hub.docker.com/r/messagebird/pushprom/ up-to-date and automatically building/pushing.

Here pushprom is built in an Alpine container, which is what the existing image uses.  I had to set `CGO_ENABLED=1` to get the build to work, which [differs from the Makefile build](https://github.com/messagebird/pushprom/blob/c3872e0223c2dac50ffde65cd31244643884c150/Makefile#L17).  I ended-up adding a multi-stage build to slim-down the final image size.

Since this uses an in-container in-Alpine toolchain, it is likely that the resulting binary is linked differently - I don't know which toolchain was used to build the binary uploaded into the existing image.

If this approach works, it should allow the existing image (last pushed 2 years ago) to be flipped-over to an automated build.