### PR TITLE
Update Dockerfile and makefilr to use mod

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN go mod download
 COPY . .
 
 # Build the binary
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -ldflags "-s -w" -installsuffix cgo -o /go/bin/pushprom .
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -ldflags "-s -w" -o /go/bin/pushprom .
 
 # <- Second step to build minimal image
 FROM scratch 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /pushprom
 COPY go.mod . 
 COPY go.sum .
 
-# Get dependancies - will also be cached if we won't change mod/sum
+# Get dependencies - will also be cached if we won't change mod/sum
 RUN go mod download
 # COPY the source code as the last step
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11.1-alpine3.8 as build-env
+FROM golang:alpine as build-env
 # All these steps will be cached
 
 RUN apk add git

--- a/Makefile
+++ b/Makefile
@@ -13,11 +13,11 @@ all:
 
 
 release_linux: 
-	dep ensure
+    go mod download
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags "-s -w" -o "bin/pushprom-$(VERSION).linux-amd64/pushprom" github.com/messagebird/pushprom
 	mv bin/pushprom-$(VERSION).linux-amd64/pushprom bin/
 
-container: release_linux
+container: 
 	@echo "* Creating $(PROJECT) Docker container"
 	@docker build -t $(PROJECT):$(VERSION) .
 	@docker tag $(PROJECT):$(VERSION) $(PROJECT):latest


### PR DESCRIPTION
The old makefile used ensure, which is not used anymore. It also did the intermediate step of compiling the image for a linux machine.
It was updated to use mod and the compilation is now done inside the dockerfile.