### PR TITLE
Fix: remove spaces and use tabs so makefile works correctly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ all:
 
 
 release_linux: 
-    go mod download
+	go mod download
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags "-s -w" -o "bin/pushprom-$(VERSION).linux-amd64/pushprom" github.com/messagebird/pushprom
 	mv bin/pushprom-$(VERSION).linux-amd64/pushprom bin/
 


### PR DESCRIPTION
Fixes the error: `Makefile:16: *** missing separator.  Stop.` which occurs when running make file ie `make container`. 

Verified the issue with command `cat -e -t -v Makefile`: 
![image](https://user-images.githubusercontent.com/6132021/149510610-983fe808-2ba9-4e04-b74b-8e43c4bd44e9.png)



