### PR TITLE
OBSV-443 fix gracefull servers shutdown and verbosity

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+bin
+docs

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-FROM golang:alpine as build-env
-# All these steps will be cached
+FROM golang:1.17-alpine as build-env
 
 RUN apk add git
 RUN mkdir /pushprom

--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,16 @@ release_linux:
 	go mod download
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags "-s -w" -o "bin/pushprom-$(VERSION).linux-amd64/pushprom" github.com/messagebird/pushprom
 	mv bin/pushprom-$(VERSION).linux-amd64/pushprom bin/
+	rm -rf bin/pushprom-$(VERSION).linux-amd64/
+	file bin/pushprom
+
+native: 
+	go clean
+	go mod download
+	CGO_ENABLED=0 go build -ldflags "-s -w" -o "bin/pushprom-native" github.com/messagebird/pushprom
+	file bin/pushprom-native
 
 container: 
-	@echo "* Creating $(PROJECT) Docker container"
-	@docker build -t $(PROJECT):$(VERSION) .
-	@docker tag $(PROJECT):$(VERSION) $(PROJECT):latest
+	echo "* Creating $(PROJECT) Docker container"
+	DOCKER_BUILDKIT=1 docker build -t $(PROJECT):$(VERSION) .
+	docker tag $(PROJECT):$(VERSION) $(PROJECT):latest

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Pushprom is a proxy (HTTP/UDP) to the [Prometheus](https://prometheus.io/) Go cl
 
 Prometheus doesn't offer a PHP client and PHP clients are hard to implement because they would need to keep track of state and PHP setups generally don't encourage that. That's why we built Pushprom.
 
-## Deprendencies
+## Dependencies
 
 - [make](https://www.gnu.org/software/make/)
 - [golang](https://go.dev/)

--- a/README.md
+++ b/README.md
@@ -7,6 +7,13 @@ Pushprom is a proxy (HTTP/UDP) to the [Prometheus](https://prometheus.io/) Go cl
 
 Prometheus doesn't offer a PHP client and PHP clients are hard to implement because they would need to keep track of state and PHP setups generally don't encourage that. That's why we built Pushprom.
 
+## Deprendencies
+
+- [make](https://www.gnu.org/software/make/)
+- [golang](https://go.dev/)
+- [docker](https://www.docker.com/)
+- [github-release](https://cli.github.com/manual/gh_release_create)
+
 ## Installing
 
 Execute the following command:
@@ -15,12 +22,27 @@ Execute the following command:
 go get -u github.com/messagebird/pushprom
 ```
 
-Or, alternatively, to build a Docker container:
+To build amd64/linux binary:
+```bash
+make release_linux
+```
+
+To build os & platform dependent native binary:
+```bash
+make native
+```
+
+To build using Docker container:
 
 ```bash
 make container
 ```
 
+## Release
+
+```bash
+VERSION=1.0.9 ./release.sh
+```
 
 ## Usage
 
@@ -40,8 +62,6 @@ $ pushprom -h
 Usage of bin/pushprom:
   -http-listen-address string
         The address to listen on for http stat and telemetry requests. (default ":9091")
-  -log-level string
-        Log level: debug, info (default), warn, error, fatal. (default "info")
   -udp-listen-address string
         The address to listen on for udp stats requests. (default ":9090")
 ```

--- a/http.go
+++ b/http.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
+	"sync"
 	"time"
 
 	"github.com/messagebird/pushprom/delta"
@@ -43,8 +45,8 @@ func (httpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func listenHTTP(ctx context.Context) {
-	log.Println("exposing metrics on http://" + *httpListenAddress + "/metrics\n")
+func listenHTTP(wg *sync.WaitGroup, ctx context.Context, stderrLogger *log.Logger, stdoutLogger *log.Logger) {
+	stdoutLogger.Println("exposing metrics on http://" + *httpListenAddress + "/metrics")
 
 	mux := http.NewServeMux()
 	mux.Handle("/metrics", promhttp.Handler())
@@ -61,19 +63,30 @@ func listenHTTP(ctx context.Context) {
 
 	mux.HandleFunc("/", postHandler)
 
-	server := http.Server{Addr: *httpListenAddress, Handler: mux}
+	server := http.Server{
+		// see https://ieftimov.com/posts/make-resilient-golang-net-http-servers-using-timeouts-deadlines-context-cancellation/
+		WriteTimeout:      10 * time.Second,
+		ReadHeaderTimeout: 10 * time.Second,
+		Addr:              *httpListenAddress,
+		Handler:           mux,
+	}
 
-	go func() {
+	go func(wg *sync.WaitGroup) {
 		<-ctx.Done()
 
-		servCtx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+		stdoutLogger.Println("shutting down http listener on " + *httpListenAddress)
+
+		servCtx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
 		err := server.Shutdown(servCtx)
 		if err != nil {
-			log.Print(err)
+			stderrLogger.Fatalf("http listener failed to shutdown gracefully: %v", err)
 		}
 		cancel()
-	}()
+		defer wg.Done()
+	}(wg)
 
-	log.Println("listening for stats on http://" + *httpListenAddress)
-	log.Fatal(server.ListenAndServe())
+	stdoutLogger.Println("listening for stats on http://" + *httpListenAddress)
+	if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		stderrLogger.Fatalf("Failed to ListenAndServe: %v", err)
+	}
 }

--- a/http.go
+++ b/http.go
@@ -86,7 +86,7 @@ func listenHTTP(wg *sync.WaitGroup, ctx context.Context, stderrLogger *log.Logge
 		stdoutLogger.Println("http listener is now offline")
 	}(wg)
 
-	stdoutLogger.Println("listening for stats on http://" + *httpListenAddress)
+	stdoutLogger.Println("listening for stats HTTP on http://" + *httpListenAddress)
 	if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		stderrLogger.Fatalf("Failed to ListenAndServe: %v", err)
 	}

--- a/http.go
+++ b/http.go
@@ -83,6 +83,7 @@ func listenHTTP(wg *sync.WaitGroup, ctx context.Context, stderrLogger *log.Logge
 		}
 		cancel()
 		defer wg.Done()
+		stdoutLogger.Println("http listener is now offline")
 	}(wg)
 
 	stdoutLogger.Println("listening for stats on http://" + *httpListenAddress)

--- a/main.go
+++ b/main.go
@@ -60,7 +60,7 @@ func handleSIGTERM(wg *sync.WaitGroup, cancel func(), infoLogger *log.Logger) {
 	sigc := make(chan os.Signal, 1)
 	signal.Notify(sigc, syscall.SIGTERM, os.Interrupt)
 	<-sigc
-	infoLogger.Println("received SIGTERM, will terminate")
+	infoLogger.Println("received termination/interrupt signal, will terminate")
 	cancel()
 	defer close(sigc)
 

--- a/release.sh
+++ b/release.sh
@@ -27,8 +27,7 @@ mkdir -p ${BIN_DIR}
 build_for linux amd64
 build_for darwin amd64
 
-docker build -t ${USER}/${REPO}:${VERSION} .
-
+DOCKER_BUILDKIT=1 docker build -t ${USER}/${REPO}:${VERSION} .
 
 git tag -a $VERSION -m "version $VERSION"
 

--- a/udp.go
+++ b/udp.go
@@ -31,6 +31,7 @@ func listenUDP(wg *sync.WaitGroup, ctx context.Context, stderrLogger *log.Logger
 			stderrLogger.Print(err)
 		}
 		defer wg.Done()
+		stdoutLogger.Println("udp listener is now offline")
 	}(serverConn, wg)
 
 	buf := make([]byte, 8192)

--- a/udp.go
+++ b/udp.go
@@ -3,32 +3,35 @@ package main
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"log"
 	"net"
+	"strings"
+	"sync"
+	"time"
 
 	"github.com/messagebird/pushprom/delta"
-
 )
 
-func listenUDP(ctx context.Context) {
-	fmt.Println("listening for stats UDP on port " + *udpListenAddress)
+func listenUDP(wg *sync.WaitGroup, ctx context.Context, stderrLogger *log.Logger, stdoutLogger *log.Logger) {
+	stdoutLogger.Println("listening for stats UDP on port " + *udpListenAddress)
 	serverAddr, err := net.ResolveUDPAddr("udp", *udpListenAddress)
 	if err != nil {
-		log.Print(err)
+		stderrLogger.Print(err)
 	}
 
 	serverConn, err := net.ListenUDP("udp", serverAddr)
 	if err != nil {
-		log.Print(err)
+		stderrLogger.Print(err)
 	}
 
-	defer func(serverConn *net.UDPConn) {
+	defer func(serverConn *net.UDPConn, wg *sync.WaitGroup) {
+		stdoutLogger.Println("closing incoming UDP port " + *udpListenAddress)
 		err := serverConn.Close()
 		if err != nil {
-			log.Print(err)
+			stderrLogger.Print(err)
 		}
-	}(serverConn)
+		defer wg.Done()
+	}(serverConn, wg)
 
 	buf := make([]byte, 8192)
 
@@ -36,28 +39,32 @@ func listenUDP(ctx context.Context) {
 		// handle cancelled context.
 		select {
 		case <-ctx.Done():
+			stdoutLogger.Println("shutting down udp listener on " + *udpListenAddress)
 			return
 		default:
 		}
 
+		serverConn.SetReadDeadline(time.Now().Add(2 * time.Second))
 		n, _, err := serverConn.ReadFromUDP(buf)
 		if err != nil {
-			log.Print("Error reading from UDP: ", err)
+			if !strings.Contains(err.Error(), "i/o timeout") {
+				stderrLogger.Print("error reading from UDP: ", err)
+			}
 			continue
 		}
 		udpPacketCount.Inc()
 
-		fmt.Printf("new udp package: %s\n", string(buf[0:n]))
+		// fmt.Printf("new udp package: %s\n", string(buf[0:n]))
 
 		newDelta, err := delta.NewDelta(bytes.NewBuffer(buf[0:n]))
 		if err != nil {
-			log.Print("Error creating delta: ", err)
+			stderrLogger.Print("Error creating delta: ", err)
 			continue
 		}
 
 		err = newDelta.Apply()
 		if err != nil {
-			log.Print("Error applying delta: ", err)
+			stderrLogger.Print("Error applying delta: ", err)
 		}
 	}
 }

--- a/udp.go
+++ b/udp.go
@@ -45,7 +45,11 @@ func listenUDP(wg *sync.WaitGroup, ctx context.Context, stderrLogger *log.Logger
 		default:
 		}
 
-		serverConn.SetReadDeadline(time.Now().Add(2 * time.Second))
+		err = serverConn.SetReadDeadline(time.Now().Add(2 * time.Second))
+		if err != nil {
+			stderrLogger.Print("failed setting read UDP deadline: ", err)
+		}
+
 		n, _, err := serverConn.ReadFromUDP(buf)
 		if err != nil {
 			if !strings.Contains(err.Error(), "i/o timeout") {


### PR DESCRIPTION
Removed debug UDP logging
Separated messages into STDOUT and STDERR using standard logger
Fixed gracefull shutdown for UDP & HTTP listeners

```
~/projects/pushprom (obsv-443 ✔) make native
go clean
go mod download
CGO_ENABLED=0 go build -ldflags "-s -w" -o "bin/pushprom-native" github.com/messagebird/pushprom
file bin/pushprom-native
bin/pushprom-native: Mach-O 64-bit executable arm64
~/projects/pushprom (obsv-443 ✔) ./bin/pushprom-native
2022/12/05 15:18:19 welcome to messagebird/pushprom
2022/12/05 15:18:19 starting listeners
2022/12/05 15:18:19 listening for stats UDP on port 0.0.0.0:9090
2022/12/05 15:18:19 exposing metrics on http://0.0.0.0:9091/metrics
2022/12/05 15:18:19 listening for stats on http://0.0.0.0:9091
2022/12/05 15:18:28 received SIGTERM, will terminate
2022/12/05 15:18:28 waiting for all servers to gracefully terminate
2022/12/05 15:18:28 shutting down http listener on 0.0.0.0:9091
2022/12/05 15:18:28 http listener is now offline
2022/12/05 15:18:29 shutting down udp listener on 0.0.0.0:9090
2022/12/05 15:18:29 closing incoming UDP port 0.0.0.0:9090
2022/12/05 15:18:29 udp listener is now offline
2022/12/05 15:18:30 all goroutines gracefully finished
~/projects/pushprom (obsv-443 ✔)
```
